### PR TITLE
Добавил ресайз изображения на клиенте

### DIFF
--- a/static/js/main.min.js
+++ b/static/js/main.min.js
@@ -8,6 +8,21 @@ $(".modal_images").click(function(){
     $(".modal_images").hide();
 });
 
+function dataURLtoBlob(dataurl) {
+    var arr = dataurl.split(','), mime = arr[0].match(/:(.*?);/)[1],
+        bstr = atob(arr[1]), n = bstr.length, u8arr = new Uint8Array(n);
+    while(n--){
+        u8arr[n] = bstr.charCodeAt(n);
+    }
+    return new Blob([u8arr], {type:mime});
+}
+
+function updateInputFile(input, file) {
+  const dataTransfer = new DataTransfer();
+  dataTransfer.items.add(file);
+  input.files = dataTransfer.files;
+}
+
 var size = 1;
 var procsize = 100;
 var topl = 0;
@@ -304,7 +319,47 @@ var test_flag = false;
         }
     });
 
-    $('#image_loadphoto_pc input').change(function(e){
+    $('#image_loadphoto_pc input').change(function(inputEvent){
+        let processing = true;
+
+        const maxSize = 1024;
+        const upload = inputEvent.target.files[0];
+
+        if (!upload || (upload.type != "image/png" && upload.type != "image/jpeg")) {
+          processing = false;
+        };
+
+        if (processing) {
+          const reader = new FileReader();
+          reader.onload = (readerEvent) => {
+            const img = document.createElement("img");
+            img.onload = (imageEvent) => {
+              const canvas = document.createElement("canvas");
+
+              if (imageEvent.target.width <= imageEvent.target.height) {
+                if (imageEvent.target.width <= maxSize) return;
+                canvas.width = maxSize;
+                canvas.height = imageEvent.target.height * (maxSize / imageEvent.target.width);
+              } else {
+                if (imageEvent.target.heigh <= maxSize) return;
+                canvas.width = imageEvent.target.width * (maxSize / imageEvent.target.height);
+                canvas.height = maxSize;
+              }
+
+              const context = canvas.getContext("2d");
+              context.drawImage(imageEvent.target, 0, 0, canvas.width, canvas.height);
+
+              updateInputFile(inputEvent.target, new File(
+                [dataURLtoBlob(context.canvas.toDataURL(imageEvent.target, upload.type))],
+                upload.name,
+                {type: upload.type}
+              ));
+              $('#image_loadphoto_pc').submit();
+            };
+            img.src = readerEvent.target.result;
+          };
+          reader.readAsDataURL(upload);
+        }
 
         if(!test_flag){
             test_flag = true;
@@ -326,7 +381,9 @@ var test_flag = false;
                 $("#image_loadphoto_pc #process_2_sides").val("False");
 
             //return false;
-            $('#image_loadphoto_pc').submit();
+            if (!processing) {
+              $('#image_loadphoto_pc').submit();
+            }
         }else{
             return false;
         }
@@ -344,7 +401,48 @@ var mob_flag = false;
         }
     });
 
-    $('#image_loadphoto input').change(function(){
+    $('#image_loadphoto input').change(function(inputEvent){
+        let processing = true;
+
+        const maxSize = 1024;
+        const upload = inputEvent.target.files[0];
+
+        if (!upload || (upload.type != "image/png" && upload.type != "image/jpeg")) {
+          processing = false;
+        };
+
+        if (processing) {
+          const reader = new FileReader();
+          reader.onload = (readerEvent) => {
+            const img = document.createElement("img");
+            img.onload = (imageEvent) => {
+              const canvas = document.createElement("canvas");
+
+              if (imageEvent.target.width <= imageEvent.target.height) {
+                if (imageEvent.target.width <= maxSize) return;
+                canvas.width = maxSize;
+                canvas.height = imageEvent.target.height * (maxSize / imageEvent.target.width);
+              } else {
+                if (imageEvent.target.heigh <= maxSize) return;
+                canvas.width = imageEvent.target.width * (maxSize / imageEvent.target.height);
+                canvas.height = maxSize;
+              }
+
+              const context = canvas.getContext("2d");
+              context.drawImage(imageEvent.target, 0, 0, canvas.width, canvas.height);
+
+              updateInputFile(inputEvent.target, new File(
+                [dataURLtoBlob(context.canvas.toDataURL(imageEvent.target, upload.type))],
+                upload.name,
+                {type: upload.type}
+              ));
+              $('#image_loadphoto').submit();
+              $(".mob_btn").html("<img class='c_load' src='/static/images/load_ci.gif' />");
+            };
+            img.src = readerEvent.target.result;
+          };
+          reader.readAsDataURL(upload);
+        }
         $("#image_loadphoto #input_lang").val($(".lang-choise").val());
         if ($("#radio1").prop('checked'))
             $("#image_loadphoto #has_public_confirm").val("True");
@@ -361,8 +459,10 @@ var mob_flag = false;
         else
             $("#image_loadphoto #process_2_sides").val("False");
 
-        $('#image_loadphoto').submit();
-         $(".mob_btn").html("<img class='c_load' src='/static/images/load_ci.gif' />");
+        if (!processing) {
+          $('#image_loadphoto').submit();
+          $(".mob_btn").html("<img class='c_load' src='/static/images/load_ci.gif' />");
+        }
     });
 
 //Форма создания фото
@@ -375,7 +475,48 @@ var mob_flag = false;
         }
     });
 
-    $('#image_mkphoto input').change(function(){
+    $('#image_mkphoto input').change(function(inputEvent){
+        let processing = true;
+
+        const maxSize = 1024;
+        const upload = inputEvent.target.files[0];
+
+        if (!upload || (upload.type != "image/png" && upload.type != "image/jpeg")) {
+          processing = false;
+        };
+
+        if (processing) {
+          const reader = new FileReader();
+          reader.onload = (readerEvent) => {
+            const img = document.createElement("img");
+            img.onload = (imageEvent) => {
+              const canvas = document.createElement("canvas");
+
+              if (imageEvent.target.width <= imageEvent.target.height) {
+                if (imageEvent.target.width <= maxSize) return;
+                canvas.width = maxSize;
+                canvas.height = imageEvent.target.height * (maxSize / imageEvent.target.width);
+              } else {
+                if (imageEvent.target.heigh <= maxSize) return;
+                canvas.width = imageEvent.target.width * (maxSize / imageEvent.target.height);
+                canvas.height = maxSize;
+              }
+
+              const context = canvas.getContext("2d");
+              context.drawImage(imageEvent.target, 0, 0, canvas.width, canvas.height);
+
+              updateInputFile(inputEvent.target, new File(
+                [dataURLtoBlob(context.canvas.toDataURL(imageEvent.target, upload.type))],
+                upload.name,
+                {type: upload.type}
+              ));
+              $('#image_mkphoto').submit();
+              $(".mob_btn").html("<img class='c_load' src='/static/images/load_ci.gif' />");
+            };
+            img.src = readerEvent.target.result;
+          };
+          reader.readAsDataURL(upload);
+        }
         $("#image_mkphoto #input_lang").val($(".lang-choise").val());
         if ($("#radio1").prop('checked'))
             $("#image_mkphoto #has_public_confirm").val("True");
@@ -392,8 +533,10 @@ var mob_flag = false;
         else
             $("#image_mkphoto #process_2_sides").val("False");
 
-        $('#image_mkphoto').submit();
-         $(".mob_btn").html("<img class='c_load' src='/static/images/load_ci.gif' />");
+        if (!processing) {
+          $('#image_mkphoto').submit();
+          $(".mob_btn").html("<img class='c_load' src='/static/images/load_ci.gif' />");
+        }
     });
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
closes #3 

Детали реализации:
- По умолчанию подменить файл в форме невозможно, т.к. этот атрибут поля read-only из соображений безопасности. Но в современном JS есть лазейка чтобы подменить весь массив файлов, тем самым изменив поле, которое read-only. Такой workaround работает [везде, кроме IE](https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList/add#browser_compatibility)
- Обработка изображения была встроена в каждый (3) обработчик `onchange`, подключенный через jQuery. В текущей реализации сделать по другому не особо получится. По хорошему от jQuery вообще нужно избавляться.
- Обработка будет осуществлена только для файлов с типом `image/png` или `image/jpeg` и с размером меньшей стороны больше 1024.

Протестировал:
- Firefox
- Мобильный эмулятор в Firefox
- Мобильная верия Firefox на Android